### PR TITLE
Revise dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ A Rust interface for SCTP. Prefers a native implementation, alternative implemen
 
 ## Summary
 
-SCTP (https://en.wikipedia.org/wiki/Stream_Control_Transmission_Protocol) is a message-based networking protocol with optional reliability and in-sequence ordering.
+[SCTP](https://en.wikipedia.org/wiki/Stream_Control_Transmission_Protocol) is a message-based networking protocol with optional reliability and in-sequence ordering.
 
 Initially, this crate aims to provide an interface to native implementations of SCTP. Due to the moderate adoption rates of SCTP, it is not always available on all platforms, such as most smartphones. Therefore an alternative implementation of SCTP over UDP tunneling is considered.
 
 Currently heavily WIP and may not compile nicely!
 
-Windows only for now, you need SctpDrv (http://www.bluestop.org/SctpDrv/) to compile.
+Windows only for now, you need [SctpDrv](https://github.com/bcran/sctpdrv) to compile.
 
 Idea is to provide a simple interface to SCTP functions in lib.rs.
 


### PR DESCRIPTION
Old link is 404, but I found what it was suppose to point to.